### PR TITLE
[bugfix] Removed `nuget` dependency checker and added `github-actions` in its place

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,10 +1,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
 version: 2
 updates:
-  - package-ecosystem: nuget
-    directories:
-      - Glekcraft/
-      - tests/Glekcraft/
+  - package-ecosystem: github-actions
+    directory: .github/workflows/
     labels:
       - Dependency
     schedule:


### PR DESCRIPTION
See ongoing conversation in dependabot/dependabot-core#11520.